### PR TITLE
Restart from single key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-stretch
+FROM golang:1.15.2-buster
 
 COPY . $GOPATH/src/mainstay
 

--- a/attestation/attestclient.go
+++ b/attestation/attestclient.go
@@ -301,9 +301,15 @@ func (w *AttestClient) GetNextAttestationKey(hash chainhash.Hash) (*btcutil.WIF,
 func (w *AttestClient) GetNextAttestationAddr(key *btcutil.WIF, hash chainhash.Hash) (
 	btcutil.Address, string, error) {
 
+	//single attestation transaction for upgrade to single key:
+	var basePub []*btcec.PublicKey
+	basePub = append(basePub, w.pubkeys[0])
+	multisigAddr, multisigScript := crypto.CreateMultisig(basePub, 1, w.MainChainCfg)
+	return multisigAddr, multisigScript, nil
+
 	// In multisig case tweak all initial pubkeys and import
 	// a multisig address to the main client wallet
-	if len(w.pubkeysExtended) > 0 {
+/*	if len(w.pubkeysExtended) > 0 {
 		// empty hash - no tweaking
 		if hash.IsEqual(&chainhash.Hash{}) {
 			multisigAddr, multisigScript := crypto.CreateMultisig(w.pubkeys, w.numOfSigs, w.MainChainCfg)
@@ -340,6 +346,7 @@ func (w *AttestClient) GetNextAttestationAddr(key *btcutil.WIF, hash chainhash.H
 		return nil, "", myAddrErr
 	}
 	return myAddr, "", nil
+*/
 }
 
 // Method to import address to client rpc wallet and report import error

--- a/attestation/attestclient.go
+++ b/attestation/attestclient.go
@@ -342,18 +342,6 @@ func (w *AttestClient) GetNextAttestationAddr(key *btcutil.WIF, hash chainhash.H
 	return myAddr, "", nil
 }
 
-
-// TEMPORARY transfer of staychain to single pubkey
-func (w *AttestClient) GetSingleKeyAddr(key *btcutil.WIF, hash chainhash.Hash) (
-	btcutil.Address, string, error) {
-
-	//single attestation transaction for upgrade to single key:
-	var basePub []*btcec.PublicKey
-	basePub = append(basePub, w.pubkeys[0])
-	multisigAddr, multisigScript := crypto.CreateMultisig(basePub, 1, w.MainChainCfg)
-	return multisigAddr, multisigScript, nil
-}
-
 // Method to import address to client rpc wallet and report import error
 // This address is required to watch unspent and mempool transactions
 // IDEALLY would import the P2SH script as well, but not supported by btcsuite

--- a/attestation/attestclient.go
+++ b/attestation/attestclient.go
@@ -301,15 +301,9 @@ func (w *AttestClient) GetNextAttestationKey(hash chainhash.Hash) (*btcutil.WIF,
 func (w *AttestClient) GetNextAttestationAddr(key *btcutil.WIF, hash chainhash.Hash) (
 	btcutil.Address, string, error) {
 
-	//single attestation transaction for upgrade to single key:
-	var basePub []*btcec.PublicKey
-	basePub = append(basePub, w.pubkeys[0])
-	multisigAddr, multisigScript := crypto.CreateMultisig(basePub, 1, w.MainChainCfg)
-	return multisigAddr, multisigScript, nil
-
 	// In multisig case tweak all initial pubkeys and import
 	// a multisig address to the main client wallet
-/*	if len(w.pubkeysExtended) > 0 {
+	if len(w.pubkeysExtended) > 0 {
 		// empty hash - no tweaking
 		if hash.IsEqual(&chainhash.Hash{}) {
 			multisigAddr, multisigScript := crypto.CreateMultisig(w.pubkeys, w.numOfSigs, w.MainChainCfg)
@@ -346,7 +340,18 @@ func (w *AttestClient) GetNextAttestationAddr(key *btcutil.WIF, hash chainhash.H
 		return nil, "", myAddrErr
 	}
 	return myAddr, "", nil
-*/
+}
+
+
+// TEMPORARY transfer of staychain to single pubkey
+func (w *AttestClient) GetSingleKeyAddr(key *btcutil.WIF, hash chainhash.Hash) (
+	btcutil.Address, string, error) {
+
+	//single attestation transaction for upgrade to single key:
+	var basePub []*btcec.PublicKey
+	basePub = append(basePub, w.pubkeys[0])
+	multisigAddr, multisigScript := crypto.CreateMultisig(basePub, 1, w.MainChainCfg)
+	return multisigAddr, multisigScript, nil
 }
 
 // Method to import address to client rpc wallet and report import error

--- a/attestation/attestservice.go
+++ b/attestation/attestservice.go
@@ -367,7 +367,7 @@ func (s *AttestService) doStateNewAttestation() {
 	if s.setFailure(keyErr) {
 		return // will rebound to init
 	}
-	paytoaddr, _, addrErr := s.attester.GetNextAttestationAddr(key, s.attestation.CommitmentHash())
+	paytoaddr, _, addrErr := s.attester.GetSingleKeyAddr(key, s.attestation.CommitmentHash())
 	if s.setFailure(addrErr) {
 		return // will rebound to init
 	}

--- a/attestation/attestservice.go
+++ b/attestation/attestservice.go
@@ -243,7 +243,12 @@ func (s *AttestService) stateInitUnspent(unspent btcjson.ListUnspentResult) {
 		log.Infoln("********** found unspent transaction, initiating staychain")
 		s.attestation = models.NewAttestationDefault()
 	}
+
 	confirmedHash := s.attestation.CommitmentHash()
+	if (s.attester.txid0 == unspentTxid.String()) {
+		log.Infoln("********** found base transaction, blank attestation")		
+		confirmedHash = chainhash.Hash{}
+	}
 	s.signer.SendConfirmedHash((&confirmedHash).CloneBytes()) // update clients
 
 	s.state = AStateNextCommitment // update attestation state
@@ -286,6 +291,18 @@ func (s *AttestService) stateInitWalletFailure() {
 		return // will rebound to init
 	}
 	log.Infof("********** importing latest unconfirmed addr: %s ...\n", paytoaddr.String())
+	importErr = s.attester.ImportAttestationAddr(paytoaddr)
+	if s.setFailure(importErr) {
+		return // will rebound to init
+	}
+
+	// import initial base address
+	paytoaddr, _, addrErr = s.attester.GetNextAttestationAddr((*btcutil.WIF)(nil), chainhash.Hash{})
+	if s.setFailure(addrErr) {
+		return // will rebound to init
+	}
+	
+	log.Infof("********** importing base init addr: %s ...\n", paytoaddr.String())
 	importErr = s.attester.ImportAttestationAddr(paytoaddr)
 	if s.setFailure(importErr) {
 		return // will rebound to init
@@ -367,7 +384,7 @@ func (s *AttestService) doStateNewAttestation() {
 	if s.setFailure(keyErr) {
 		return // will rebound to init
 	}
-	paytoaddr, _, addrErr := s.attester.GetSingleKeyAddr(key, s.attestation.CommitmentHash())
+	paytoaddr, _, addrErr := s.attester.GetNextAttestationAddr(key, s.attestation.CommitmentHash())
 	if s.setFailure(addrErr) {
 		return // will rebound to init
 	}
@@ -533,6 +550,9 @@ func (s *AttestService) doStateAwaitConfirmation() {
 		s.attester.Fees.ResetFee(s.isRegtest) // reset client fees
 
 		confirmedHash := s.attestation.CommitmentHash()
+		if (s.attester.txid0 == s.attestation.Txid.String()) {
+			confirmedHash = chainhash.Hash{}
+		}
 		s.signer.SendConfirmedHash((&confirmedHash).CloneBytes()) // update clients
 
 		s.state = AStateNextCommitment // update attestation state


### PR DESCRIPTION
Changes to enable signing of transaction spending from a new base txid without any commitment. 